### PR TITLE
チーム登録の流れ修正

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,10 +11,9 @@ class TeamsController < ApplicationController
   end
 
   def create
-    @team = Team.create(team_params)
-    @team.update(admin_user_id: current_user.id)
-    @user.update(team_id: @team.id)
-    redirect_to main_team_path(@team)
+    @team = Team.new(team_params)
+    session["team"] = @team.attributes
+    redirect_to users_registrations_admin_signup_path
   end
 
   def show

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -11,7 +11,8 @@ class TeamsController < ApplicationController
   end
 
   def create
-    @team = Team.new(team_params)
+    @team = Team.create(team_params)
+    # binding.pry
     session["team"] = @team.attributes
     redirect_to users_registrations_admin_signup_path
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,12 +20,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def admin_create
     @user = User.create(user_params)
-    @user.update(admin: 1)
-    @team = Team.new(session["team"])
-    @team = Team.create(@team.attributes)
-    @user.update(team_id: @team.id)
+    @team = Team.find(session["team"]["id"])
+    @user.update(admin: 1, team_id: @team.id)
     @team.update(admin_user_id: @user.id)
-    sign_in(:user, @user)
+    a = sign_in(:user, @user)
     redirect_to main_team_path(@team.id)
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,8 +21,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def admin_create
     @user = User.create(user_params)
     @user.update(admin: 1)
+    @team = Team.new(session["team"])
+    @team = Team.create(@team.attributes)
+    @user.update(team_id: @team.id)
+    @team.update(admin_user_id: @user.id)
     sign_in(:user, @user)
-    redirect_to new_team_path(@user)
+    redirect_to main_team_path(@team.id)
   end
 
   # GET /resource/edit

--- a/app/views/devise/registrations/admin_new.html.haml
+++ b/app/views/devise/registrations/admin_new.html.haml
@@ -7,15 +7,6 @@
       %br
       %span.login__title__description
         あなたのチームを登録しましょう
-    -# = form_with model: @team, url:teams_path , class: "Box", local: true do |f|
-    -#   .signup
-    -#     .signup__name
-    -#     = f.label :name, class: "signUpForm__label"
-    -#     = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
-    -#     = f.label :Team_image, class: "signUpForm__label"
-    -#     = f.file_field :image, class: "signupForm1"
-    -#     = f.submit "次へ進む", class: "signUpBtn"
-
     まずは選手としてのあなたを登録しましょう
     = form_with model: @user, url:users_registrations_admin_create_path , class: "Box", local: true do |f|
       .signup

--- a/app/views/devise/registrations/admin_new.html.haml
+++ b/app/views/devise/registrations/admin_new.html.haml
@@ -7,33 +7,33 @@
       %br
       %span.login__title__description
         あなたのチームを登録しましょう
-    = form_with model: @team, url:teams_path , class: "Box", local: true do |f|
-      .signup
-        .signup__name
-        = f.label :name, class: "signUpForm__label"
-        = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
-        = f.label :Team_image, class: "signUpForm__label"
-        = f.file_field :image, class: "signupForm1"
-        = f.submit "次へ進む", class: "signUpBtn"
-
-    -# まずは選手としてのあなたを登録しましょう
-    -# = form_with model: @user, url:users_registrations_admin_create_path , class: "Box", local: true do |f|
+    -# = form_with model: @team, url:teams_path , class: "Box", local: true do |f|
     -#   .signup
     -#     .signup__name
     -#     = f.label :name, class: "signUpForm__label"
     -#     = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
-    -#     .signup__email
-    -#     = f.label :email, class: "signUpForm__label"
-    -#     = f.email_field :email, placeholder: "PC・携帯どちらでも可", class: "signupForm1"
-    -#     .signup__password
-    -#     = f.label :password, class: "signUpForm__label"
-    -#     = f.password_field :password, placeholder: "7文字以上の半角英数字", class: "signUpPassword1"
-    -#     %span.infoText__span
-    -#       ※英字と数字の両方を含めて設定してください
-    -#     .signUpPassWord
-    -#     = f.label :password_confirmation, "パスワード確認", class: "signUpForm__label"
-    -#     %span.signUpPassWord__span
-    -#       必須
-    -#     = f.password_field :password_confirmation, placeholder: "上記と同じパスワードを入力してください", class: "signUpPassword1"
-    -#     %span.infoText__span
+    -#     = f.label :Team_image, class: "signUpForm__label"
+    -#     = f.file_field :image, class: "signupForm1"
     -#     = f.submit "次へ進む", class: "signUpBtn"
+
+    まずは選手としてのあなたを登録しましょう
+    = form_with model: @user, url:users_registrations_admin_create_path , class: "Box", local: true do |f|
+      .signup
+        .signup__name
+        = f.label :name, class: "signUpForm__label"
+        = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
+        .signup__email
+        = f.label :email, class: "signUpForm__label"
+        = f.email_field :email, placeholder: "PC・携帯どちらでも可", class: "signupForm1"
+        .signup__password
+        = f.label :password, class: "signUpForm__label"
+        = f.password_field :password, placeholder: "7文字以上の半角英数字", class: "signUpPassword1"
+        %span.infoText__span
+          ※英字と数字の両方を含めて設定してください
+        .signUpPassWord
+        = f.label :password_confirmation, "パスワード確認", class: "signUpForm__label"
+        %span.signUpPassWord__span
+          必須
+        = f.password_field :password_confirmation, placeholder: "上記と同じパスワードを入力してください", class: "signUpPassword1"
+        %span.infoText__span
+        = f.submit "次へ進む", class: "signUpBtn"

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -5,7 +5,7 @@
         = image_tag "A6.png", class: "logo"
         %h3 サッカーチームの管理を、もっとスマートに。
       .sign
-        = link_to "チームを作成", users_registrations_admin_signup_path
+        = link_to "チームを作成", new_team_path
         = link_to "ログイン", new_user_session_path
     .description
       .description__title

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -11,6 +11,6 @@
         .signup__name
         = f.label :name, class: "signUpForm__label"
         = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
-        = f.label :Team_image, class: "signUpForm__label"
+        = f.label :image, class: "signUpForm__label"
         = f.file_field :image, class: "signupForm1"
         = f.submit "次へ進む", class: "signUpBtn"

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,6 +1,16 @@
-= form_with model: @team, url:teams_path , class: "Box", local: true do |f|
-  .signup
-    .signup__name
-    = f.label :name, class: "signUpForm__label"
-    = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
-    = f.submit "次へ進む", class: "signUpBtn"
+.main-wrapper.login
+  = render partial: "homes/login_sidebar"
+  %main
+    %h2.login__title 
+      Create your Team
+      %br
+      %span.login__title__description
+        あなたのチームを登録しましょう
+    = form_with model: @team, url:teams_path , class: "Box", local: true do |f|
+      .signup
+        .signup__name
+        = f.label :name, class: "signUpForm__label"
+        = f.text_field :name, class: "signupForm1", placeholder: "例) メルカリ太郎"
+        = f.label :Team_image, class: "signUpForm__label"
+        = f.file_field :image, class: "signupForm1"
+        = f.submit "次へ進む", class: "signUpBtn"

--- a/db/migrate/20200912032454_add_column_to_users.rb
+++ b/db/migrate/20200912032454_add_column_to_users.rb
@@ -1,5 +1,5 @@
 class AddColumnToUsers < ActiveRecord::Migration[6.0]
   def change
-    add_reference :users, :team, foreign_key: true
+    add_reference :users, :team, optional: true
   end
 end


### PR DESCRIPTION
#WHAT
チームを作成する流れを下記の様に変更した
チームを作成する　→　そのチームの管理者権限を持ったユーザを作成する

#WHY
ユーザー視点で考えた際に
まずは「チームを管理したい」という困りごとにフォーカスを当てる必要があり、以上からまずはチームを作成する画面に遷移した方が有用であると考えたから