### PR TITLE
試合出欠確認機能

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -24,10 +24,9 @@ class GamesController < ApplicationController
 
   def show
     @game = Game.find(params[:id])
-    @players = GamesUser.includes(:user).where(game_id: @game.id, status: "yes")
-    @not_going_players = GamesUser.includes(:user).where(game_id: @game.id, status: "no")
-    @notyet_players = GamesUser.includes(:user).where(game_id: @game.id, status: "notyet")
-    # binding.pry
+    @going_players = GamesUser.eager_load(:user,:game).where(game_id: @game.id, status: "yes")
+    @not_going_players = GamesUser.eager_load(:user,:game).where(game_id: @game.id, status: "no")
+    @notyet_players = GamesUser.eager_load(:user,:game).where(game_id: @game.id, status: "notyet")
   end
 
   def edit

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -6,7 +6,8 @@ class TeamsController < ApplicationController
   def main
     @team = Team.find(params[:id])
     #今日以降で直近のGameレコードを一つ取得
-    @latest_game = Game.where('team_id = ? and date >= ? ', @team.id, Date.today).order(date: "ASC").limit(1) 
+    @latest_game = Game.where('team_id = ? and date >= ? ', @team.id, Date.today).order(date: "ASC").limit(1)[0]
+    # binding.pry
   end
 
   def new

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -5,6 +5,8 @@ class TeamsController < ApplicationController
 
   def main
     @team = Team.find(params[:id])
+    #今日以降で直近のGameレコードを一つ取得
+    @latest_game = Game.where('team_id = ? and date >= ? ', @team.id, Date.today).order(date: "ASC").limit(1) 
   end
 
   def new
@@ -13,7 +15,6 @@ class TeamsController < ApplicationController
 
   def create
     @team = Team.create(team_params)
-    # binding.pry
     session["team"] = @team.attributes
     redirect_to users_registrations_admin_signup_path
   end

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -15,9 +15,7 @@
             %li.tab.is-active 
               試合概要
             %li.tab
-              参加メンバー
-            %li.tab
-              参加未確認メンバー
+              出欠確認
           .panel-group
             .panel.is-show
               .game-box-wrapper
@@ -49,29 +47,39 @@
             .panel
               .game-box-wrapper
                 %h2 
-                  参加メンバー
                   %span
-                    = @notyet_players.count 
+                    参加者
+                    = @going_players.count 
                     名
                 .game-box
                   .game-box__left
+                    参加者
                   .game-box__right
-                    - @notyet_players.each do |player|
-                      - player = player.user 
-                      = player.name
-            .panel
-              .game-box-wrapper
-                %h2 
-                  参加未確認メンバー
-                  %span
-                    = @notyet_players.count 
-                    名
                 .game-box
                   .game-box__left
+                    - @going_players.each do |player|
+                      = player.user.name
                   .game-box__right
+                .game-box
+                  .game-box__left
+                    欠席者
+                  .game-box__right
+                .game-box
+                  .game-box__left
+                    - @not_going_players.each do |player|
+                      = player.user.name
+                  .game-box__right
+                .game-box
+                  .game-box__left
+                    未提出者
+                  .game-box__right
+                .game-box
+                  .game-box__left
                     - @notyet_players.each do |player|
-                      - player = player.user 
-                      = player.name
+                      = player.user.name
+                  .game-box__right
+
+
 
 
       

--- a/app/views/teams/main.html.haml
+++ b/app/views/teams/main.html.haml
@@ -6,22 +6,30 @@
     .main-container
       .box.next-game
         %h2.box__header
-          = "#{@team.name}の次の試合"
+          = link_to team_game_path(@team.id, @latest_game.id) do
+            = "#{@team.name}の次の試合"
         .next-game__opponent.mini-box
-          .next-game__left　対戦相手
-          .next-game__right　セレッソ大阪
+          .next-game__left
+            対戦相手
+          .next-game__right 
+            = @latest_game.opponent
         .next-game__date.mini-box
-          .next-game__left  日にち
-          .next-game__right　2020年09月26日
-        .next-game__time.mini-box
-          .next-game__left　時間
-          .next-game__right　09:00 ~ 12:00
-        .next-game__place.mini-box
-          .next-game__left 場所
+          .next-game__left  
+            日にち
           .next-game__right
-            J-GREEN境
-            .next-game__right__details
-              〒590-0132 大阪府堺市南区原山台５丁１３−４３
+            = @latest_game.date
+        .next-game__time.mini-box
+          .next-game__left
+            時間
+          .next-game__right
+            = @latest_game.time
+        .next-game__place.mini-box
+          .next-game__left 
+            場所
+          .next-game__right
+            = @latest_game.place
+            -# .next-game__right__details
+            -#   〒590-0132 大阪府堺市南区原山台５丁１３−４３
       .box.calendar
         ここにカレンダーが入ります
       .box.confirmation


### PR DESCRIPTION
#WHAT
試合出欠確認機能を実装した
・試合詳細ページのマークアップ
・メインページに最新の試合の詳細ページへ飛ぶ様リンクを付与
・最新の試合を取得するコードをアクションに追加（いずれモデルでメソッド化する）

#WHY
どの試合に対して誰が参加するかしないかもしくは出欠を表明していないかが可視化されることによって
管理者の出欠管理タスクが軽くなるから