### PR TITLE
試合出欠報告リマインド機能

### DIFF
--- a/app/assets/stylesheets/games/_index.scss
+++ b/app/assets/stylesheets/games/_index.scss
@@ -12,7 +12,6 @@
       padding: 30px;
       width: 100%;
       margin: 0 auto;
-  
     .game-box{
       display: flex;
       margin: 15px 0;
@@ -23,6 +22,25 @@
       &__right{
         width: 60%;
         font-size: $sFontL;
+      }
+      & .name{
+        font-size: $sFontM;
+      }
+      & .btn{
+        background-color: $cDeepBlue;
+        color: white;
+        border-radius: 5px;
+        background-color: $cDeepBlue;
+        width: 15%;
+        margin-left: 50%;
+      }
+      .fa-bell{
+        color: white;
+        margin-left: 10px;
+        padding: 2px 5px;
+        font-size: 1.3em;
+        border-radius: 5px;
+        background-color: $cDeepBlue;
       }
     }
   }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -30,15 +30,24 @@ class GamesController < ApplicationController
 
   def show
     @game = Game.find(params[:id])
-    @going_players = GamesUser.eager_load(:user,:game).where(game_id: @game.id, status: "yes")
-    @not_going_players = GamesUser.eager_load(:user,:game).where(game_id: @game.id, status: "no")
-    @notyet_players = GamesUser.eager_load(:user,:game).where(game_id: @game.id, status: "notyet")
+    @members = GamesUser.eager_load(:user, :status).where(game_id: @game.id)
+    @going_members = GamesUser.where('game_id = ? and status_id = ?', @game.id, 2) 
   end
 
   def edit
   end
 
   def update
+  end
+
+  def send_remind
+    @game = Game.find(params[:id])
+    @members = @team.users
+    @members.each do |member|
+      @game.create_notification_remind_event(current_user, member.id)
+    end
+    flash[:success] = "通知を送りました"
+    redirect_to team_game_path(@team.id, @game.id)
   end
 
   private

--- a/app/controllers/games_users_controller.rb
+++ b/app/controllers/games_users_controller.rb
@@ -9,7 +9,7 @@ class GamesUsersController < ApplicationController
   end
 
   def update
-    @games_user.update(status: "yes")
+    @games_user.update(status: "2")
     unless @games_user.valid?
       flash.now[:alert] = @games_user.errors.full_messages
       render 'users/show' and return
@@ -18,7 +18,7 @@ class GamesUsersController < ApplicationController
   end
 
   def update_no
-    @games_user.update(status: "no")
+    @games_user.update(status_id: "3")
     unless @games_user.valid?
       flash.now[:alert] = @games_user.errors.full_messages
       render 'users/show' and return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
   end
 
   def set_games_users
-    @games_users = GamesUser.includes(:game).where('user_id = ? and status = ?', current_user.id, 'notyet')
+    @games_users = GamesUser.includes(:game).where('user_id = ? and status_id = ?', current_user.id, 1)
   end
 
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -32,4 +32,15 @@ class Game < ApplicationRecord
     # 自分へは通知が作られない・届かないようにする
     notification.save if notification.visitor_id != notification.visited_id && notification.valid?
   end
+
+  # ◆通知機能（リマインド）
+  def create_notification_remind_event(current_user, visited_id)
+    notification = current_user.active_notifications.new(
+      game_id: id,
+      visited_id: visited_id,
+      action: 'remind_game'
+    )
+    # 自分へは通知が作られない・届かないようにする
+    notification.save if notification.visitor_id != notification.visited_id && notification.valid?
+  end
 end

--- a/app/models/games_user.rb
+++ b/app/models/games_user.rb
@@ -1,4 +1,5 @@
 class GamesUser < ApplicationRecord
   belongs_to :game
   belongs_to :user
+  belongs_to :status
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,3 @@
+class Status < ApplicationRecord
+  has_many :games_users
+end

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -49,38 +49,19 @@
                 %h2 
                   %span
                     参加者
-                    = @going_players.count 
+                    = @going_members.count
                     名
-                .game-box
-                  .game-box__left
-                    参加者
-                  .game-box__right
-                .game-box
-                  .game-box__left
-                    - @going_players.each do |player|
-                      = player.user.name
-                  .game-box__right
-                .game-box
-                  .game-box__left
-                    欠席者
-                  .game-box__right
-                .game-box
-                  .game-box__left
-                    - @not_going_players.each do |player|
-                      = player.user.name
-                  .game-box__right
-                .game-box
-                  .game-box__left
-                    未提出者
-                  .game-box__right
-                .game-box
-                  .game-box__left
-                    - @notyet_players.each do |player|
-                      = player.user.name
-                  .game-box__right
-
-
-
-
-      
-        
+                - @members.each do |member|
+                  .game-box
+                    .game-box__left.name
+                      = member.user.name
+                    .game-box__right.btn
+                      - if member.status_id == 1
+                        未確認
+                      - if member.status_id == 2
+                        参加
+                      - if member.status_id == 3
+                        不参加
+                    - if member.status_id == 1
+                      = link_to send_remind_team_game_path(@team.id, @game.id) ,method: :post do
+                        %i.fas.fa-bell

--- a/app/views/notifications/_notifications.html.haml
+++ b/app/views/notifications/_notifications.html.haml
@@ -3,18 +3,41 @@
   - visitor = notification.visitor
   - visited = notification.visited
   .notice__box
+  - case notification.action
+  - when "new_game"
     %p
       下記の試合が追加されました
     %p.notice__box__info
-      = notification.game.date.month
-      %span /
-      = notification.game.date.day
-      %span (
-      = %w(日 月 火 水 木 金 土)[notification.game.date.wday]
-      %span ) 
-      &emsp;
-      = notification.game.time.strftime(' %H:%M')
-      &emsp;
-      = notification.game.opponent
-      &emsp;
-      = notification.game.place
+      = link_to team_game_path(@team.id, notification.game.id) do
+        = notification.game.date.month
+        %span /
+        = notification.game.date.day
+        %span (
+        = %w(日 月 火 水 木 金 土)[notification.game.date.wday]
+        %span ) 
+        &emsp;
+        = notification.game.begin_time.strftime(' %H:%M')
+        &emsp;
+        = notification.game.opponent
+        &emsp;
+        = notification.game.place
+  - when "remind_game"
+    %p
+      = visited.name
+      さんから以下の試合の出欠報告のリマインドが届きました
+    %p.notice__box__info
+      = link_to team_game_path(@team.id, notification.game.id) do
+        = notification.game.date.month
+        %span /
+        = notification.game.date.day
+        %span (
+        = %w(日 月 火 水 木 金 土)[notification.game.date.wday]
+        %span ) 
+        &emsp;
+        = notification.game.begin_time.strftime(' %H:%M')
+        &emsp;
+        = notification.game.opponent
+        &emsp;
+        = notification.game.place
+
+    

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -41,7 +41,7 @@
                           = %w(日 月 火 水 木 金 土)[games_user.game.date.wday]
                           %span ) 
                           &emsp;
-                          = games_user.game.time.strftime(' %H:%M')
+                          = games_user.game.begin_time.strftime(' %H:%M')
                           &emsp;
                           = games_user.game.opponent
                           &emsp;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   resources :teams do
     resources :notifications, only: :index
     resources :games do
+      member do
+        post "send_remind"
+      end
       resources :games_users, only: [:edit, :update] do
         member do
           patch "update_no"

--- a/db/migrate/20200914090000_create_statuses.rb
+++ b/db/migrate/20200914090000_create_statuses.rb
@@ -1,0 +1,9 @@
+class CreateStatuses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :statuses do |t|
+      t.string :status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200914140633_create_games_users.rb
+++ b/db/migrate/20200914140633_create_games_users.rb
@@ -1,8 +1,9 @@
 class CreateGamesUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :games_users do |t|
-      t.references :game, null: false, foreign_key: true
+      t.references :game, type: :bigint, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
+      t.references :status, default: 1, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20200917070321_add_status_to_games_users.rb
+++ b/db/migrate/20200917070321_add_status_to_games_users.rb
@@ -1,5 +1,0 @@
-class AddStatusToGamesUsers < ActiveRecord::Migration[6.0]
-  def change
-    add_column :games_users, :status, :string, default: 'notyet', null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_17_070321) do
+ActiveRecord::Schema.define(version: 2020_09_15_080939) do
 
   create_table "emails", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email"
@@ -34,10 +34,11 @@ ActiveRecord::Schema.define(version: 2020_09_17_070321) do
   create_table "games_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "game_id", null: false
     t.bigint "user_id", null: false
+    t.bigint "status_id", default: 1, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status", default: "notyet", null: false
     t.index ["game_id"], name: "index_games_users_on_game_id"
+    t.index ["status_id"], name: "index_games_users_on_status_id"
     t.index ["user_id"], name: "index_games_users_on_user_id"
   end
 
@@ -47,6 +48,12 @@ ActiveRecord::Schema.define(version: 2020_09_17_070321) do
     t.integer "game_id", null: false
     t.string "action", default: "", null: false
     t.boolean "checked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -78,5 +85,6 @@ ActiveRecord::Schema.define(version: 2020_09_17_070321) do
 
   add_foreign_key "games", "teams"
   add_foreign_key "games_users", "games"
+  add_foreign_key "games_users", "statuses"
   add_foreign_key "games_users", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,13 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Status.create!(
+  [
+    {
+      status: "notyet"
+    },
+    {
+      status: "yes"
+    },
+    {
+      status: "no"
+    }
+  ]
+)

--- a/test/fixtures/statuses.yml
+++ b/test/fixtures/statuses.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  status: MyString
+
+two:
+  status: MyString

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StatusTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#WHAT
試合の出欠報告が未提出のメンバーにリマインドを送る機能を実装した

#WHY
ボタン一つで出欠報告のリマインドを送れることでマネージャーの負担が大きく減るから